### PR TITLE
invalid token now rejects automatic login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.1]
+### Changed
+-  the provider finds a cookie with a token, and makes the portals/self call but gets a 200 response that contains an error payload, reject the promise so that the app does not *think* the user is logged in.
+
+
 ## [0.2.0]
 ### Added
 - option to redirect to static page for *much* faster iframe auth flows

--- a/app/torii-adapters/arcgis-oauth-bearer.js
+++ b/app/torii-adapters/arcgis-oauth-bearer.js
@@ -50,7 +50,14 @@ export default Ember.Object.extend({
       Ember.$.ajax({
         url: portalSelfUrl,
         dataType: 'json',
-        success: Ember.run.bind(null, resolve),
+        success: Ember.run.bind(null, function(data){
+          Ember.debug('torii:adapter:arcgis-oauth-bearer:open portals/self call returned: ' + JSON.stringify(data));
+          if(data.error){
+            reject(data);
+          }else{
+            resolve(data);
+          }
+        }),
         error: Ember.run.bind(null, reject)
       });
 


### PR DESCRIPTION
When the provider finds a cookie/local-storage entry with a token, and makes the portals/self call but gets a 200 response that contains an error payload, reject the promise so that the app does not *think* the user is logged in.