### PR TITLE
oauth-bearer gains new options and handles them differently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Versioning](http://semver.org/).
 ## Fixed
 - null reference error because this was undefined
 
+## Changed
+- arcgis-oauth-bearer handles options differently - we now do not `set` the options on the bearer
+- arcgis-oath-bearer now handles additional queryString params: autoAccountCreateForSocial & socialLoginProviderName
+
 ## [0.6.0]
 ### Added
 - `isAdmin()` which will returnt true if `role === 'org_admin' && !roleId` - which is how we know if a user is a FULL org admin

--- a/app/torii-providers/query-string.js
+++ b/app/torii-providers/query-string.js
@@ -1,5 +1,9 @@
 import Ember from 'ember';
-// import QueryString from 'torii/lib/query-string';
+
+/*
+  NOTE: this is mostly the same implementation as the default torii implementation
+          the difference is that it takes an `options` which it uses when constructing the querystring
+*/
 
 var camelize = Ember.String.camelize,
     get      = Ember.get;

--- a/app/torii-providers/query-string.js
+++ b/app/torii-providers/query-string.js
@@ -1,0 +1,84 @@
+import Ember from 'ember';
+// import QueryString from 'torii/lib/query-string';
+
+var camelize = Ember.String.camelize,
+    get      = Ember.get;
+
+function isValue(value){
+  return (value || value === false);
+}
+
+function getParamValue(obj, paramName, optional){
+  var camelizedName = camelize(paramName),
+      value         = get(obj, camelizedName);
+
+  if (!optional) {
+    if ( !isValue(value) && isValue(get(obj, paramName))) {
+      throw new Error(
+        'Use camelized versions of url params. (Did not find ' +
+        '"' + camelizedName + '" property but did find ' +
+        '"' + paramName + '".');
+    }
+
+    if (!isValue(value)) {
+      throw new Error(
+        'Missing url param: "'+paramName+'". (Looked for: property named "' +
+        camelizedName + '".'
+      );
+    }
+  }
+
+  return isValue(value) ? encodeURIComponent(value) : undefined;
+}
+
+function getOptionalParamValue(obj, paramName){
+  return getParamValue(obj, paramName, true);
+}
+
+export default Ember.Object.extend({
+  init: function() {
+    this.obj               = this.provider;
+    this.urlParams         = Ember.A(this.requiredParams).uniq();
+    this.optionalUrlParams = Ember.A(this.optionalParams || []).uniq();
+
+    this.optionalUrlParams.forEach(function(param){
+      if (this.urlParams.indexOf(param) > -1) {
+        throw new Error("Required parameters cannot also be optional: '" + param + "'");
+      }
+    }, this);
+  },
+
+  toString: function() {
+    const urlParams = this.urlParams;
+    const optionalUrlParams = this.optionalUrlParams;
+    const obj = this.obj;
+    const keyValuePairs = Ember.A([]);
+
+    const options = this.get('options');
+    const optionsKeys = Object.keys(options);
+
+    urlParams.forEach((paramName) => {
+      if (!optionsKeys.includes(paramName)) {
+        var paramValue = getParamValue(obj, paramName);
+        keyValuePairs.push([paramName, paramValue]);
+      }
+    });
+
+    optionalUrlParams.forEach((paramName) => {
+      if (!optionsKeys.includes(paramName)) {
+        var paramValue = getOptionalParamValue(obj, paramName);
+        if (isValue(paramValue)) {
+          keyValuePairs.push([paramName, paramValue]);
+        }
+      }
+    });
+
+    optionsKeys.forEach((paramName) => {
+      keyValuePairs.push([paramName, encodeURIComponent(options[paramName])]);
+    });
+
+    return keyValuePairs.map(function(pair){
+      return pair.join('=');
+    }).join('&');
+  }
+});


### PR DESCRIPTION
arcgis-oauth-bearer now handles options passed to `open` differently and also handles a few additional options.

We now do not `set` the options on the bearer. Before, if you passed options to `open` we would set them on the bearer. This meant that any subsequent calls to `open` would also use those options. We now do now do that; we instead just use those options to generate the url without setting them on the bearer.

New options:
- portalHostname - overrides the configured portalHostname
- path - overrides the default path (/sharing/oauth2/authorize)

New URL params:
- autoAccountCreateForSocial
- socialLoginProviderName