### PR TITLE
always store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic
 Versioning](http://semver.org/).
 
-## Unreleased
+
+## 0.10.0
+### Changed
+- always store token - even if using iframe. This is because portal may not set the `esri_auth` cookie during it's login process, if it's not perfectly configured. So - we will just always store the credentials ourselves.
+
+## 0.9.0
 ### Changed
 - upgrade to torii v 0.8.4 for compatibility with ember > 2.12.0
 

--- a/app/torii-adapters/arcgis-oauth-bearer.js
+++ b/app/torii-adapters/arcgis-oauth-bearer.js
@@ -95,14 +95,9 @@ export default Ember.Object.extend({
       // drop the user node from the portalSelf response
       delete portal.user;
 
-      // TODO find a cleaner means to handle this iframe jiggery pokery
-      if (!ENV.torii.providers['arcgis-oauth-bearer'].display || ENV.torii.providers['arcgis-oauth-bearer'].display !== 'iframe') {
-        // basically - if we are not using the iframe, we need to handle the
-        // login persistence ourselves so cook up an object and stuff it
-        // in localStorage
-        let cookieData = this._createCookieData(token, expires, user, portal);
-        this._store('torii-provider-arcgis', cookieData);
-      }
+      // always store the information
+      let cookieData = this._createCookieData(token, expires, user, portal);
+      this._store('torii-provider-arcgis', cookieData);
 
       return {
         portal: portal,


### PR DESCRIPTION
Always store the auth info - change from previous when it would only store if not using iframe auth. Will have no impact on users not hosting apps on `*.arcgis.com` and *should* have no impact for those who are hosting apps on `*.arcgis.com`